### PR TITLE
ci: Check Pull Request Title

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -1,0 +1,18 @@
+name: "Pull Request Tasks"
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check-pull-request-title:
+    name: Check Pull Request Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Pull Request Title
+        uses: deepakputhraya/action-pr-title@v1.0.2
+        with:
+          allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: ,build(deps): " # title should start with the given prefix


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new GitHub Actions workflow to automate tasks related to pull requests. The most important change is the addition of a workflow configuration file that checks the pull request title for specific prefixes.

New GitHub Actions workflow:

* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfR1-R18): Added a new workflow named "Pull Request Tasks" that triggers on pull request events (opened, edited, synchronize) and includes a job to check the pull request title using the `deepakputhraya/action-pr-title` action. The allowed prefixes for the title are specified in the configuration.

Fixes #19 
