### PR TITLE
ci: Check Justfile Format

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -77,3 +77,17 @@ jobs:
           queries: security-and-quality
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.28.0
+
+  check-justfile-format:
+    name: Check Justfile Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Just
+        uses: extractions/setup-just@v2
+      - name: Check Justfile Format
+        run: just format-check

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,11 @@
+# ------------------------------------------------------------------------------
+# Justfile
+# ------------------------------------------------------------------------------
+
+# Format the Just code
+format:
+    just --fmt --unstable
+
+# Check for Just format issues
+format-check:
+    just --fmt --check --unstable


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new workflow to check the format of the `Justfile` in the repository. The changes include adding a new job in the GitHub Actions workflow and updating the `Justfile` with new commands for formatting and checking the format.

### Workflow Addition:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R80-R93): Added a new job named `check-justfile-format` to the GitHub Actions workflow. This job sets up Just and runs a format check on the `Justfile`.

### Justfile Updates:

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cR1-R11): Added commands to format the Just code and check for format issues. The `format` command formats the Just code, and the `format-check` command checks for format issues.

Fixes #18 
