### PR TITLE
ci: Add CodeLimit Checks

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -91,3 +91,18 @@ jobs:
         uses: extractions/setup-just@v2
       - name: Check Justfile Format
         run: just format-check
+
+  run-code-limit:
+    name: Run CodeLimit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: "Run CodeLimit"
+        uses: getcodelimit/codelimit-action@v1


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new workflow to the GitHub Actions configuration in the `.github/workflows/code-checks.yml` file. The key change is the addition of a job to run CodeLimit, which is a tool for enforcing code limits.

New workflow addition:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R94-R108): Added a new job named `run-code-limit` to execute CodeLimit, including steps for checking out the repository and running the CodeLimit action.

Fixes #45 
