### PR TITLE
chore: Add Python Dependabot Dependency Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,21 @@ updates:
         update-types:
           - "patch"
           - "minor"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    commit-message:
+      prefix: "deps(python)"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "01:00"
+      timezone: "Europe/London"
+    target-branch: "main"
+    groups:
+      python:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a significant update to the `.github/dependabot.yml` file to add a new package ecosystem for Python dependencies. The most important changes include the addition of a new configuration for managing Python dependencies with Dependabot.

Dependabot configuration update:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R22-R39): Added a new package ecosystem configuration for `pip` to manage Python dependencies. This includes setting the commit message prefix to "deps(python)", scheduling updates weekly on Saturdays at 01:00 in the Europe/London timezone, targeting the `main` branch, and grouping updates by patterns and types (patch and minor).

Fixes #51 
