### PR TITLE
chore: Add GitHub Action Summary

### DIFF
--- a/validator/__main__.py
+++ b/validator/__main__.py
@@ -10,6 +10,7 @@ from .types import AnalysedRepositories
 from json import dump
 from dataclasses import asdict
 from .action_summary import generate_action_summary
+
 logger: stdlib.BoundLogger = get_logger()
 
 

--- a/validator/__main__.py
+++ b/validator/__main__.py
@@ -9,7 +9,7 @@ from .repository_checks import check_repository
 from .types import AnalysedRepositories
 from json import dump
 from dataclasses import asdict
-
+from .action_summary import generate_action_summary
 logger: stdlib.BoundLogger = get_logger()
 
 
@@ -27,6 +27,7 @@ def main() -> None:
     )
     with open("repositories.json", "w") as file:
         dump(analysed_repositories, file, indent=4)
+    generate_action_summary(analysed_repositories)
     logger.info(
         "Repositories analysed",
         repositories=analysed_repositories,

--- a/validator/action_summary.py
+++ b/validator/action_summary.py
@@ -1,0 +1,22 @@
+from os import environ
+from pathlib import Path
+from json import dump
+
+from structlog import get_logger, stdlib
+
+logger: stdlib.BoundLogger = get_logger()
+
+
+def generate_action_summary(analysed_repositories: dict) -> None:
+    """Generate the action summary.
+
+    Args:
+        analysed_repositories (dict): The analysed repositories.
+    """
+
+    if "GITHUB_STEP_SUMMARY" in environ:
+        logger.debug("Running in GitHub Actions, generating action summary")
+        with Path(environ["GITHUB_STEP_SUMMARY"]).open("w") as file:
+            dump(analysed_repositories, file, indent=4)
+    else:
+        logger.debug("Not running in GitHub Actions, skipping generating action summary")

--- a/validator/action_summary.py
+++ b/validator/action_summary.py
@@ -19,4 +19,6 @@ def generate_action_summary(analysed_repositories: dict) -> None:
         with Path(environ["GITHUB_STEP_SUMMARY"]).open("w") as file:
             dump(analysed_repositories, file, indent=4)
     else:
-        logger.debug("Not running in GitHub Actions, skipping generating action summary")
+        logger.debug(
+            "Not running in GitHub Actions, skipping generating action summary"
+        )


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new feature to generate an action summary for analysed repositories when running in GitHub Actions. The most important changes include the addition of the `generate_action_summary` function and its integration into the main script.

New feature implementation:

* [`validator/action_summary.py`](diffhunk://#diff-77c11df08149daefb1c1ad1854ac2f65039667e33bae6f9286080c2abbc15650R1-R24): Added the `generate_action_summary` function to generate an action summary based on the analysed repositories. This function checks if the code is running in GitHub Actions and writes the summary to a specified file.

Integration into main script:

* [`validator/__main__.py`](diffhunk://#diff-ced1c51874c3ff41a0cc0fcbb923f510becf15a3c3b07a78ba5ee9b105eb2211R12): Imported the `generate_action_summary` function and called it after dumping the analysed repositories to a JSON file. [[1]](diffhunk://#diff-ced1c51874c3ff41a0cc0fcbb923f510becf15a3c3b07a78ba5ee9b105eb2211R12) [[2]](diffhunk://#diff-ced1c51874c3ff41a0cc0fcbb923f510becf15a3c3b07a78ba5ee9b105eb2211R31)

Fixes #28 
