### PR TITLE
ci: Upgrade Markdown Link Checker

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -42,7 +42,7 @@ jobs:
 
   check-markdown-links:
     name: Check Markdown links
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
@@ -50,7 +50,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.2.4
+        uses: UmbrellaDocs/action-linkspector@v1.2.5
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the GitHub Actions workflow configuration file `.github/workflows/code-checks.yml`. The changes are aimed at updating the environment and dependencies used for the Markdown link check job.

Updates to the GitHub Actions workflow:

* Updated the `runs-on` parameter to use `ubuntu-latest` instead of a specific version `ubuntu-22.04` to ensure the job always runs on the latest available version of Ubuntu.
* Updated the `uses` parameter for the `Check Markdown links` step to use `UmbrellaDocs/action-linkspector@v1.2.5` instead of `v1.2.4`, ensuring the job uses the latest version of the action.