### PR TITLE
ci: Update SuperLinter Permissions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -26,11 +26,11 @@ jobs:
           persist-credentials: false
       # Lint and Format everything but Python
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7.2.1
+        uses: super-linter/super-linter/slim@v7.3.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: .github/super-linter-configurations
           YAML_ERROR_ON_WARNING: true
           VALIDATE_PYTHON_BLACK: false


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the `.github/workflows/code-checks.yml` file to update the version of the super-linter used for linting and to correct the GitHub token environment variable.

* Updated the `super-linter` version from `v7.2.1` to `v7.3.0` in the `Lint Code Base` step.
* Corrected the GitHub token environment variable from `${{ secrets.GH_TOKEN }}` to `${{ secrets.GITHUB_TOKEN }}` in the `Lint Code Base` step.