### PR TITLE
ci: Validate Lefthook Configuration

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.3.1
+        uses: UmbrellaDocs/action-linkspector@v1.3.4
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml
@@ -78,13 +78,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.10
+        uses: github/codeql-action/init@v3.28.15
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
           config-file: .github/other-configurations/codeql-config.yml
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.10
+        uses: github/codeql-action/analyze@v3.28.15
 
   check-justfile-format:
     name: Check Justfile Format
@@ -133,7 +133,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.10
+        uses: github/codeql-action/upload-sarif@v3.28.15
         with:
           sarif_file: results.sarif
           category: zizmor
@@ -159,7 +159,7 @@ jobs:
           RUFF_OUTPUT_FILE: "ruff-results.sarif"
         continue-on-error: true
       - name: Upload Ruff analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v3.28.10
+        uses: github/codeql-action/upload-sarif@v3.28.15
         with:
           sarif_file: ruff-results.sarif
           wait-for-processing: true
@@ -238,7 +238,23 @@ jobs:
       - name: Run Unit Tests
         run: just unit-test
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v5.0.0
+        uses: SonarSource/sonarqube-scan-action@v5.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  lefthook-validate:
+    name: Lefthook Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5.4.2
+        with:
+          version: "latest"
+      - name: Run Lefthook Validate
+        run: uvx lefthook validate


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several dependencies in the `.github/workflows/code-checks.yml` file and introduces a new job for Lefthook validation. The updates aim to ensure the workflows use the latest versions of their respective actions, while the new job enhances pre-commit hook validation.

### Dependency Updates:

* Updated `UmbrellaDocs/action-linkspector` from `v1.3.1` to `v1.3.4` for Markdown link checking.
* Updated `github/codeql-action` for initialization, analysis, and SARIF uploads from `v3.28.10` to `v3.28.15` to ensure the latest security and analysis features. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L81-R87) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L136-R136) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L162-R162)
* Updated `SonarSource/sonarqube-scan-action` from `v5.0.0` to `v5.1.0` for SonarCloud scanning.

### New Job:

* Added a `lefthook-validate` job to validate pre-commit hooks using `uvx lefthook validate`. This includes steps for repository checkout and installing the latest version of `uv`.