### PR TITLE
chore: Update Dependabot Groups and Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,18 +2,21 @@ version: 2
 
 updates:
   - package-ecosystem: "github-actions"
-    directories:
-      - "/"
+    directory: "/"
     commit-message:
       prefix: "deps(github-actions)"
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       github-actions:
+        applies-to: "version-updates"
         patterns:
           - "*"
+        exclude-patterns:
+          - "super-linter/*"
         update-types:
           - "patch"
           - "minor"
@@ -25,9 +28,11 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       python:
+        applies-to: "version-updates"
         patterns:
           - "*"
         update-types:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/dependabot.yml` configuration to improve the dependency update process by consolidating directories, adding timezone support, and refining grouping rules.

### Dependabot configuration improvements:

* Consolidated the `directories` field for `github-actions` updates into a single `directory` field for simplicity (`/` instead of a list).
* Added a `timezone` field (`Europe/London`) to the schedule configuration for better control over the timing of updates. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L5-R19) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R31-R35)
* Introduced the `applies-to` field for both `github-actions` and `python` groups to specify that the rules apply to "version-updates." [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L5-R19) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R31-R35)
* Updated the `github-actions` group to exclude updates matching the `super-linter/*` pattern, providing more granular control over dependency updates.