### PR TITLE
chore: Fix Zizmor SARIF Command

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -125,14 +125,16 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Set up dependencies
-        uses: ./.github/actions/setup-dependencies
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+      - name: Set up Just
+        uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
       - name: Run zizmor 🌈
-        run: uv run zizmor --format sarif . > results.sarif
+        run: just zizmor-check-sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.15
+        uses: github/codeql-action/upload-sarif@v3.28.17
         with:
           sarif_file: results.sarif
           category: zizmor

--- a/Justfile
+++ b/Justfile
@@ -151,7 +151,11 @@ lefthook-validate:
 
 # Run zizmor checking
 zizmor-check:
-    zizmor . --pedantic --persona=pedantic
+    uvx zizmor . --persona=pedantic
+
+# Run zizmor checking with sarif output
+zizmor-check-sarif:
+    uvx zizmor . --persona=pedantic --format sarif > results.sarif
 
 # ------------------------------------------------------------------------------
 # Pinact


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the workflow and build process by replacing the dependency setup and execution commands with newer tools and versions. The most important changes include switching from a custom dependency setup action to third-party actions, updating the command for running `zizmor` checks, and using a newer version of the SARIF upload action.

### Workflow updates:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L128-R137): Replaced the custom `setup-dependencies` action with `astral-sh/setup-uv` (v6.0.1) and `extractions/setup-just` (v3). This modernizes the dependency setup process.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L128-R137): Updated the SARIF upload action to `github/codeql-action/upload-sarif@v3.28.17` for improved compatibility and features.

### Command updates:

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL154-R158): Modified the `zizmor-check` command to use `uvx` instead of `zizmor` directly, ensuring compatibility with the updated setup.
* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL154-R158): Added a new `zizmor-check-sarif` command to generate SARIF output, aligning with the workflow's updated execution process.

These changes collectively improve the maintainability and functionality of the workflows and build processes.