### PR TITLE
ci: Change Jobs to Common Pull Request Tasks

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -8,6 +8,15 @@ permissions:
   pull-requests: read
 
 jobs:
+  check-pull-request-title:
+    name: Check Pull Request Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Pull Request Title
+        uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16 # v1.0.2
+        with:
+          allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: ,build(deps): " # title should start with the given prefix
+
   common-pull-request-tasks:
     name: Common Pull Request Tasks
     permissions:


### PR DESCRIPTION
# Pull Request

## Description

This pull request refactors the `.github/workflows/pull-request-tasks.yml` file by consolidating multiple individual jobs into a reusable workflow, simplifying the configuration and improving maintainability.

### Workflow refactoring:

* Removed the `check-pull-request-title`, `labeller`, and `dependency-review` jobs, along with their respective steps and configurations. These tasks are now handled by a reusable workflow.
* Introduced a single `common-pull-request-tasks` job that uses the `JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml` reusable workflow. This reduces redundancy and centralizes common pull request tasks.