### PR TITLE
deps(github-actions): Bump astral-sh/setup-uv to 6.0.1

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -4,11 +4,8 @@ description: "Installs dependencies for the project"
 runs:
   using: "composite"
   steps:
-    - name: Install Python and UV
-      uses: astral-sh/setup-uv@1edb52594c857e2b5b13128931090f0640537287 # v5.3.0
-      with:
-        pyproject-file: "pyproject.toml"
-        enable-cache: true
+    - name: Install the latest version of uv
+      uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
     - name: Set up Just
       uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
     - name: Install Python Dependencies

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -194,19 +194,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
-  lefthook-validate:
-    name: Lefthook Validate
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
-        with:
-          version: "latest"
-      - name: Run Lefthook Validate
-        run: uvx lefthook validate


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to dependency management and workflow configurations, focusing on simplifying and modernizing the setup process. The most important changes include upgrading the `setup-uv` action to the latest version and removing the `lefthook-validate` job from the CI workflow.

### Dependency Management Updates:
* Updated the `setup-uv` action in `.github/actions/setup-dependencies/action.yml` to use version `v6.0.1` instead of `v5.3.0`, simplifying the configuration by removing the `pyproject-file` and `enable-cache` options.

### Workflow Configuration Changes:
* Removed the `lefthook-validate` job from `.github/workflows/code-checks.yml`, which included steps for checking out the repository, installing `uv`, and running Lefthook validation. This streamlines the CI workflow by eliminating unused validation steps.
