### PR TITLE
ci: Remove Lefthook Validate Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -193,19 +193,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
-  lefthook-validate:
-    name: Lefthook Validate
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
-        with:
-          version: "latest"
-      - name: Run Lefthook Validate
-        run: uvx lefthook validate


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes the `lefthook-validate` job from the `.github/workflows/code-checks.yml` file, simplifying the CI workflow by eliminating an unused validation step.

### CI Workflow Simplification:
* Removed the `lefthook-validate` job, including steps for repository checkout, `uv` installation, and running `lefthook validate`. This change reduces complexity and maintenance overhead in the CI pipeline. (`[.github/workflows/code-checks.ymlL196-L211](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L196-L211)`)