### PR TITLE
chore: Set Python Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.13-alpine AS builder
 WORKDIR /
 
 COPY pyproject.toml uv.lock ./
-RUN pip install --no-cache-dir uv==0.7.4 && \
+RUN pip install --no-cache-dir uv==0.7.5 && \
   uv export --format=requirements-txt > requirements.txt
 
 FROM python:3.13-alpine AS validator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "repo_standards_validator"
 dynamic = ["version"]
-requires-python = ">=3.13"
+requires-python = "~=3.13"
 dependencies = [
   "structlog==25.3.0",
   "pygithub==2.6.0",
@@ -19,7 +19,7 @@ dev = [
 ]
 
 [tool.uv]
-required-version = "0.7.4"
+required-version = "0.7.5"
 package = false
 
 [tool.setuptools]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 2
-requires-python = ">=3.13"
+requires-python = ">=3.13, <4"
 
 [[package]]
 name = "attrs"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `pyproject.toml` file to adjust Python version requirements and update a development tool version.

Dependency updates:

* Changed `requires-python` from `>=3.13` to `~=3.13` to enforce compatibility with Python 3.13 while allowing minor updates. (`pyproject.toml`, [pyproject.tomlL4-R4](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L4-R4))
* Updated the `required-version` for the `uv` tool from `0.7.4` to `0.7.5`. (`pyproject.toml`, [pyproject.tomlL22-R22](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L22-R22))
