### PR TITLE
ci: Migrate to Reusable CodeQL Workflow

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -51,28 +51,17 @@ jobs:
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  run-codeql-analysis:
+  codeql-checks:
     name: CodeQL Analysis
-    runs-on: ubuntu-latest
     permissions:
-      statuses: write
+      contents: read
       security-events: write
     strategy:
       matrix:
-        language: [python, actions]
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@45775bd8235c68ba998cffa5171334d58593da47 # v3.28.15
-        with:
-          languages: ${{ matrix.language }}
-          queries: security-and-quality
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@45775bd8235c68ba998cffa5171334d58593da47 # v3.28.15
+        language: [actions, python]
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@75ceb782a5815a98162de1321c852df74830a493 # v2025.05.24.01
+    with:
+      language: ${{ matrix.language }}
 
   run-code-limit:
     name: Run CodeLimit


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the CodeQL analysis workflow in the `.github/workflows/code-checks.yml` file to streamline its configuration by using a reusable workflow. The most significant changes involve renaming the job, modifying permissions, and replacing inline steps with a reference to the reusable workflow.

### Workflow updates:

* Renamed the `run-codeql-analysis` job to `codeql-checks` for consistency.
* Adjusted permissions for the job, changing `statuses: write` to `contents: read` while retaining `security-events: write`.
* Replaced the inline steps for initializing and performing CodeQL analysis with a reference to the reusable workflow `JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml`. This simplifies the workflow configuration and ensures consistency across workflows.