### PR TITLE
chore: Update Tags

### DIFF
--- a/.github/other-configurations/labels.yml
+++ b/.github/other-configurations/labels.yml
@@ -29,22 +29,6 @@
 - color: d876e3
   name: wontfix
   description: The issue is expected and will not be fixed
-# Release Please
-- color: ededed
-  name: "autorelease: pending"
-  description:
-- color: ededed
-  name: "autorelease: tagged"
-  description:
-- color: ededed
-  name: "autorelease: triggered"
-  description:
-- color: ededed
-  name: "autorelease: snapshot"
-  description:
-- color: ededed
-  name: "autorelease: published"
-  description:
 # Languages
 - color: 2b67c6
   name: python


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes several labels related to the "Release Please" automation from the `.github/other-configurations/labels.yml` file. These labels are no longer needed and have been cleaned up.

Label cleanup:

* Removed the following labels: `"autorelease: pending"`, `"autorelease: tagged"`, `"autorelease: triggered"`, `"autorelease: snapshot"`, and `"autorelease: published"`. These labels were associated with the "Release Please" automation and are no longer in use.
