### PR TITLE
ci: Add release package workflow

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Run GitHub Stats Analyser (pre-built image)
+      - name: Run repo_standards_validator (pre-built image)
         uses: ./
         with:
           REPOSITORY_OWNER: ${{ github.REPOSITORY_OWNER }}

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,0 +1,71 @@
+name: Release Package
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-push-package:
+    name: Build and Push Package
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Log in to the Container registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0 # v6.17.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+  test-action:
+    name: Test Action
+    needs: build-and-push-package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Run GitHub Stats Analyser (pre-built image)
+        uses: ./
+        with:
+          REPOSITORY_OWNER: ${{ github.REPOSITORY_OWNER }}
+      - name: Test Output
+        run: tests/test_output.sh

--- a/Justfile
+++ b/Justfile
@@ -51,7 +51,7 @@ clean:
 clean-repos:
     rm -rf validator/cloned_repositories/** || true
 
-# Remove all generated files from running analyser
+# Remove all generated files from running validator
 clean-generated-files:
     rm repositories.json || true
 

--- a/run.sh
+++ b/run.sh
@@ -7,7 +7,7 @@ if [ "$CI" = "true" ]; then
   cd ..
 fi
 
-# Run the analyser
+# Run validator
 python -m validator
 
 if [ "$CI" = "true" ]; then

--- a/validator/configuration.py
+++ b/validator/configuration.py
@@ -5,7 +5,7 @@ from typing import Self
 
 @dataclass
 class Configuration:
-    """Configuration for the analyser."""
+    """Configuration for the validator."""
 
     repository_owner: str
     github_token: str


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new GitHub Actions workflow for releasing packages and makes several updates to rename the "analyser" to "validator" throughout the codebase. Below is a summary of the most important changes:

### New GitHub Actions Workflow

* Added `.github/workflows/release-package.yml` to automate the process of building, pushing, and testing Docker images upon tagging a new version. This includes steps for logging into the container registry, extracting metadata, building and pushing the Docker image, generating artifact attestations, and running tests.

### Renaming "Analyser" to "Validator"

* Updated comments in `Justfile` to reflect the renaming, changing "analyser" to "validator" in the `clean-generated-files` section.
* Updated a comment in `run.sh` to rename "analyser" to "validator" and ensured the script runs the `validator` module.
* Modified the docstring in `validator/configuration.py` to rename "analyser" to "validator" in the `Configuration` class description.