### PR TITLE
build: Sort Repositories Alphabetically

### DIFF
--- a/validator/__main__.py
+++ b/validator/__main__.py
@@ -26,9 +26,7 @@ def main() -> None:
     repositories = retrieve_repositories(configuration)
     raw_analysed_repositories = []
     total_repositories = repositories.totalCount
-    repositories = sorted(
-        repositories, key=lambda repo: repo.full_name.lower()
-    )
+    repositories = sorted(repositories, key=lambda repo: repo.full_name.lower())
     for index, repository in enumerate(repositories, 1):
         clone_repository(repository.name, repository.clone_url)
         analysed_repository = check_repository(configuration, repository)

--- a/validator/__main__.py
+++ b/validator/__main__.py
@@ -26,6 +26,9 @@ def main() -> None:
     repositories = retrieve_repositories(configuration)
     raw_analysed_repositories = []
     total_repositories = repositories.totalCount
+    repositories = sorted(
+        repositories, key=lambda repo: repo.full_name.lower()
+    )
     for index, repository in enumerate(repositories, 1):
         clone_repository(repository.name, repository.clone_url)
         analysed_repository = check_repository(configuration, repository)


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a small but significant improvement to the `main` function in `validator/__main__.py`. The change ensures that repositories are sorted alphabetically by their full names before processing.

* [`validator/__main__.py`](diffhunk://#diff-ced1c51874c3ff41a0cc0fcbb923f510becf15a3c3b07a78ba5ee9b105eb2211R29-R31): Added sorting of the `repositories` list by `repo.full_name.lower()` to ensure consistent alphabetical order when processing repositories.
