### PR TITLE
ci: Fix Release Package Workflow

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Run repo_standards_validator (pre-built image)
         uses: ./
         with:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           REPOSITORY_OWNER: ${{ github.REPOSITORY_OWNER }}
       - name: Test Output
         run: tests/test_output.sh


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small update to the `.github/workflows/release-package.yml` file, adding the `GITHUB_TOKEN` input to the `repo_standards_validator` step to enable secure authentication.

* [`.github/workflows/release-package.yml`](diffhunk://#diff-3099c6260c6951cb01f86e1ae6d3445e822dfd243571b51a1737ec2cee3a7e56R69): Added `GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}` to the `repo_standards_validator` step to provide the necessary token for authentication.