### PR TITLE
ci: Force Colour in Code Checks Workflow

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -12,6 +12,9 @@ permissions:
   contents: read
   packages: read
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   check-code-quality:
     name: Check Code Quality


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small addition to the `.github/workflows/code-checks.yml` file. It introduces an environment variable, `FORCE_COLOR`, to enforce colored output during the workflow execution.