### PR TITLE
ci: Set Workflow Job Name

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -12,6 +12,7 @@ permissions: {}
 
 jobs:
   configure-labels:
+    name: Configure Labels
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/workflows/sync-labels.yml` file. The change adds a name (`Configure Labels`) to the `configure-labels` job.