### PR TITLE
chore: Update License to Licence

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -10,7 +10,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 dependencies:


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor correction to the file pattern in the `markdown:` label configuration. The change ensures that the label correctly matches the intended file name.

* Updated the pattern from `LICENSE` to `LICENCE` in the `.github/other-configurations/labeller.yml` file to match the correct spelling of the license file.